### PR TITLE
Added test case for multiple get with invalid wildcard parameter

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,7 +52,7 @@ target_link_libraries (test_webpa_set -lwrp-c -ldbus-1 -lccsp_common -lwdmp-c -l
 #-------------------------------------------------------------------------------
 #   test_webpa_notification
 #-------------------------------------------------------------------------------
-add_test(NAME test_webpa_notification COMMAND ${MEMORY_CHECK} ./test_webpa_set)
+add_test(NAME test_webpa_notification COMMAND ${MEMORY_CHECK} ./test_webpa_notification)
 add_executable(test_webpa_notification test_webpa_notification.c mock_stack.c ../source/app/libpd.c ${WEBPA_COMMON_SOURCES})
 target_link_libraries (test_webpa_notification -lwrp-c -ldbus-1 -lccsp_common -lwdmp-c -lcjson ${WEBPA_COMMON_LIBS} -llibparodus)
 


### PR DESCRIPTION
Crash is observed for this test case on release image. So added to verify in parodus2ccsp code.