### PR TITLE
abort from configure if thread support isn't found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ include_directories (SYSTEM /usr/include)
 
 # pthread external dependency
 #-------------------------------------------------------------------------------
-find_package (Threads)
+find_package (Threads REQUIRED)
 
 # Get git commit hash
 #-------------------------------------------------------------------------------

--- a/source/app/libpd.c
+++ b/source/app/libpd.c
@@ -4,6 +4,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
+#include <pthread.h>
+
 #include "libpd.h"
 #include "webpa_adapter.h"
 

--- a/source/broadband/webpa_internal.c
+++ b/source/broadband/webpa_internal.c
@@ -6,6 +6,8 @@
  * Copyright (c) 2015  Comcast
  */
 
+#include <pthread.h>
+
 #include "webpa_internal.h"
 
 /*----------------------------------------------------------------------------*/

--- a/source/broadband/webpa_notification.c
+++ b/source/broadband/webpa_notification.c
@@ -6,6 +6,8 @@
  * Copyright (c) 2015  Comcast
  */
 
+#include <pthread.h>
+
 #include "webpa_notification.h"
 #include "webpa_internal.h"
 

--- a/source/broadband/webpa_parameter.c
+++ b/source/broadband/webpa_parameter.c
@@ -5,6 +5,9 @@
  *
  * Copyright (c) 2015  Comcast
  */
+
+#include <pthread.h>
+
 #include "webpa_internal.h"
 #include "webpa_notification.h"
 


### PR DESCRIPTION
Ensure that not finding a working pthreads library causes the build
to fail (rather than continue and produce more cryptic errors later
on).

Also ensure that the pthreads header is included in sources which
call pthreads APIs.

Signed-off-by: Andre McCurdy <armccurdy@gmail.com>